### PR TITLE
Safely parse YAML without deserializing objects

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -18,6 +18,7 @@ Install pecl yaml for php yaml support
 apt-get install php-pear libyaml-dev php5-dev
 pecl install yamL
 sh -c "echo 'extension=yaml.so' >> /etc/php5/mods-available/yaml.ini"
+sh -c "echo 'yaml.decode_php=0' >> /etc/php5/mods-available/yaml.ini"
 php5enmod yaml
 </pre>
 
@@ -37,7 +38,7 @@ DocumentRoot /path/to/here/public
 nginx:
 
 
-## Usage 
+## Usage
 
 ## Contributors
 

--- a/scripts/validate_yaml.py
+++ b/scripts/validate_yaml.py
@@ -10,8 +10,8 @@ import yaml
 def main(filename): 
     try:
         file_content = open(filename).read()
-        yaml_data = yaml.load(file_content)
-    except Exception as e: 
+        yaml_data = yaml.safe_load(file_content)
+    except Exception as e:
         sys.stderr.write("Failed to load file %s - invalid YAML: %s \n" % (filename, str(e)))
         print file_content
         sys.exit(3)


### PR DESCRIPTION
By default the PHP and Python YAML parsers will parse and create objects which are specified in a YAML file. This is a potential security risk as it could allow an attacker to escalate privileges or gain code execution by passing malicious YAML files from another system.