### PR TITLE
a few remap_purge fixes

### DIFF
--- a/roles/atsconf/tasks/main.yml
+++ b/roles/atsconf/tasks/main.yml
@@ -43,7 +43,7 @@
 
 - name: Make sure remap_purge state file directory exists
   file:
-    path: "/etc/remap_purge/"
+    path: "/usr/local/trafficserver/remap_purge/"
     state: directory
     mode: '0777'
   tags:

--- a/roles/atsconf/tasks/main.yml
+++ b/roles/atsconf/tasks/main.yml
@@ -41,6 +41,16 @@
     - ats
     - ats_logging
 
+- name: Make sure remap_purge state file directory exists
+  file:
+    path: "/etc/remap_purge/"
+    state: directory
+    mode: '0777'
+  tags:
+    - ats
+    - tls
+    - setup
+
 - name: remap config
   template:
     src: remap.config.j2

--- a/roles/atsconf/templates/remap.config.j2
+++ b/roles/atsconf/templates/remap.config.j2
@@ -43,7 +43,7 @@ regex_map http://.*/.well-known/acme-challenge http://{{le_url}}/.well-known/acm
 {%- set pluginconf = pluginconf0 + pluginconf1 + pluginconf2 -%}
 {% macro pluginconf_for_site_and_mapping(site, map_name) %}
 {%- if remap[site]["ats_purge_secret"] is defined and remap[site]["ats_purge_secret"] -%}
-{{pluginconf ~ " @plugin=remap_purge.so @pparam=--header=ATS-Purger @pparam=--secret=" ~ remap[site]["ats_purge_secret"] ~ " @pparam=--state-file=/tmp/remap_purge/" ~ site ~ "-" ~ map_name}}
+{{pluginconf ~ " @plugin=remap_purge.so @pparam=--header=ATS-Purger @pparam=--secret=" ~ remap[site]["ats_purge_secret"] ~ " @pparam=--state-file=/usr/local/trafficserver/remap_purge/" ~ site ~ "-" ~ map_name}}
 {%- else -%}
 {{pluginconf}}
 {%- endif -%}

--- a/roles/atsconf/templates/remap.config.j2
+++ b/roles/atsconf/templates/remap.config.j2
@@ -43,7 +43,7 @@ regex_map http://.*/.well-known/acme-challenge http://{{le_url}}/.well-known/acm
 {%- set pluginconf = pluginconf0 + pluginconf1 + pluginconf2 -%}
 {% macro pluginconf_for_site_and_mapping(site, map_name) %}
 {%- if remap[site]["ats_purge_secret"] is defined and remap[site]["ats_purge_secret"] -%}
-{{pluginconf ~ " @plugin=purge_remap.so @pparam=–-header=ATS-Purger @pparam=--secret=" ~ remap[site]["ats_purge_secret"] ~ " @pparam=--state-file=/tmp/purge_remap/" ~ site ~ "-" ~ map_name}}
+{{pluginconf ~ " @plugin=remap_purge.so @pparam=--header=ATS-Purger @pparam=--secret=" ~ remap[site]["ats_purge_secret"] ~ " @pparam=--state-file=/tmp/remap_purge/" ~ site ~ "-" ~ map_name}}
 {%- else -%}
 {{pluginconf}}
 {%- endif -%}


### PR DESCRIPTION
* we need to make sure a writable directory exists for the state files: i'm hardcoding`/tmp/remap_purge/` but maybe it should be parameterized somewhere
* i got bit for the 3rd time (?) by some invisible unicode character copy/pasting the "dash dash" options from the trafficserver docs (which change `--` into some em dash kinda thing i think)
* i spelled the plugin wrong: the correct spelling is `remap_purge.so` instead of `purge_remap.so`.