### PR TITLE
Vkontakte social network new range added

### DIFF
--- a/roles/atsconf/templates/banjax/whitelist.bconf.j2
+++ b/roles/atsconf/templates/banjax/whitelist.bconf.j2
@@ -154,6 +154,7 @@ white_lister:
     - 17.58.0.0/16
     # Vkontakte social
     - 87.240.128.0/18
+    - 195.211.20.0/22
     # odnoklassniki social
     - 5.61.16.0/21
     - 217.20.144.0/20


### PR DESCRIPTION
Vkontakte social network new range added (Mail.Ru Infrastructure as VK is owned by MAIL.Ru)