### PR TITLE
add kafka-related stuff to banjax config

### DIFF
--- a/roles/atsconf/defaults/main.yml
+++ b/roles/atsconf/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 dynamic_banjax: true
-
+kafka_broker_ip: '127.0.0.1'
+banjax_ssl_key_password: ''

--- a/roles/atsconf/defaults/main.yml
+++ b/roles/atsconf/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+dynamic_banjax: true
+

--- a/roles/atsconf/defaults/main.yml
+++ b/roles/atsconf/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-dynamic_banjax: true
+dynamic_banjax: false
 kafka_broker_ip: '127.0.0.1'
 banjax_ssl_key_password: ''

--- a/roles/atsconf/tasks/banjax.yml
+++ b/roles/atsconf/tasks/banjax.yml
@@ -55,6 +55,7 @@
   with_dict: "{{ dnets }}"
   tags:
     - banjax
+    - banjaxd
 
 - name: Whitelists template
   template:
@@ -64,6 +65,7 @@
   with_dict: "{{ dnets }}"
   tags:
     - banjax
+    - banjaxd
     - banjax_whitelist
 
 - name: banjax.d/dynamic.bconf configuration file

--- a/roles/atsconf/tasks/banjax.yml
+++ b/roles/atsconf/tasks/banjax.yml
@@ -77,3 +77,30 @@
   tags:
     - banjax
     - banjaxd
+
+- name: create kafka key.pem
+  template:
+    src: banjax/key.pem.j2
+    dest: "{{ banjax_output }}{{ item.key }}/key.pem"
+  with_dict: "{{ dnets }}"
+  tags:
+    - banjax
+    - banjax_kafka_certs
+
+- name: create kafka certificate.pem
+  template:
+    src: banjax/certificate.pem.j2
+    dest: "{{ banjax_output }}{{ item.key }}/certificate.pem"
+  with_dict: "{{ dnets }}"
+  tags:
+    - banjax
+    - banjax_kafka_certs
+
+- name: create kafka caroot.pem
+  template:
+    src: banjax/caroot.pem.j2
+    dest: "{{ banjax_output }}{{ item.key }}/caroot.pem"
+  with_dict: "{{ dnets }}"
+  tags:
+    - banjax
+    - banjax_kafka_certs

--- a/roles/atsconf/tasks/banjax.yml
+++ b/roles/atsconf/tasks/banjax.yml
@@ -72,7 +72,6 @@
     dest: "{{ banjax_output }}{{ item.key }}/banjax.d/dynamic.bconf"
     validate: 'python scripts/validate_yaml.py %s'
   with_dict: "{{ dnets }}"
-  when: dynamic_banjax
   tags:
     - banjax
     - banjaxd

--- a/roles/atsconf/tasks/banjax.yml
+++ b/roles/atsconf/tasks/banjax.yml
@@ -28,6 +28,25 @@
     - banjax
     - setup
 
+- name: Create banjax config dir
+  file:
+    path: "config/banjax"
+    state: directory
+    mode: '0755'
+  tags:
+    - banjax
+    - setup
+
+- name: Create banjax/dnet config dir
+  file:
+    path: "config/banjax/{{item.key}}"
+    state: directory
+    mode: '0755'
+  with_dict: "{{ dnets }}"
+  tags:
+    - banjax
+    - setup
+
 - name: Banjax configuration file
   template:
     src: banjax/banjax.conf.j2

--- a/roles/atsconf/tasks/banjax.yml
+++ b/roles/atsconf/tasks/banjax.yml
@@ -65,3 +65,14 @@
   tags:
     - banjax
     - banjax_whitelist
+
+- name: banjax.d/dynamic.bconf configuration file
+  template:
+    src: banjax/dynamic.bconf.j2
+    dest: "{{ banjax_output }}{{ item.key }}/banjax.d/dynamic.bconf"
+    validate: 'python scripts/validate_yaml.py %s'
+  with_dict: "{{ dnets }}"
+  when: dynamic_banjax
+  tags:
+    - banjax
+    - banjaxd

--- a/roles/atsconf/tasks/main.yml
+++ b/roles/atsconf/tasks/main.yml
@@ -141,3 +141,4 @@
     - banjax
     - banjaxd
     - banjax_whitelist
+    - setup

--- a/roles/atsconf/templates/banjax/banjax.conf.j2
+++ b/roles/atsconf/templates/banjax/banjax.conf.j2
@@ -20,7 +20,42 @@ include:
 challenger:
   key: {{challenger_key}}
   difficulty: 8
+  dynamic_challenger_config:
+    name: "from-kafka-challenge"
+    challenge_type: "sha_inverse"
+    challenge: "solver.html"
+    magic_word:
+      - ['regexp', '.*']
+    validity_period: 360000   # how long a cookie stays valid for
+    white_listed_ips:         # XXX i needed this for some reason
+      - '0.0.0.0'
+    no_of_fails_to_ban: 10    # XXX think about what this should be...
+  dynamic_expiry_seconds: 60  # remove dynamic challenges after this long
 
 bot_sniffer:
   botbanger_port: 22621
   key: "{{botbanger_key}}"
+
+kafka:
+  metadata.broker.list: "{{kafka_broker_ip}}"
+  security.protocol: 'ssl'
+  ssl.ca.location: "{{TSPATH}}/conf/banjax/caroot.pem"
+  ssl.certificate.location: "/{{TSPATH}}/banjax/certificate.pem"
+  ssl.key.location: "/TSPATH/banjax/key.pem"
+  ssl.key.password: "{{banjax_ssl_key_password}}"
+  report_topic: 'banjax_report_topic'
+  command_topic: 'banjax_command_topic'
+  ats_metrics_to_report:
+    - "proxy.process.traffic_server.memory.rss"
+    - "proxy.node.cache.contents.num_docs"
+    - "proxy.process.cache.bytes_total"
+    - "proxy.process.cache.percent_full"
+    - "proxy.process.cache.ram_cache.bytes_used"
+    - "proxy.process.cache.ram_cache.total_bytes"
+    - "proxy.process.net.connections_currently_open"
+    - "proxy.process.current_server_connections"
+    - "proxy.process.http.current_active_client_connections"
+    - "proxy.process.eventloop.time.max"
+
+remove_expired_challenges_interval_seconds: 30
+report_status_interval_seconds: 15

--- a/roles/atsconf/templates/banjax/banjax.conf.j2
+++ b/roles/atsconf/templates/banjax/banjax.conf.j2
@@ -16,46 +16,14 @@ include:
   - banjax.d/general.bconf
   - banjax.d/whitelist.bconf
   - banjax.d/sites.bconf
+{% if dynamic_banjax %}
+  - banjax.d/dynamic.bconf
+{% endif %}
 
 challenger:
   key: {{challenger_key}}
   difficulty: 8
-  dynamic_challenger_config:
-    name: "from-kafka-challenge"
-    challenge_type: "sha_inverse"
-    challenge: "solver.html"
-    magic_word:
-      - ['regexp', '.*']
-    validity_period: 360000   # how long a cookie stays valid for
-    white_listed_ips:         # XXX i needed this for some reason
-      - '0.0.0.0'
-    no_of_fails_to_ban: 10    # XXX think about what this should be...
-  dynamic_expiry_seconds: 60  # remove dynamic challenges after this long
 
 bot_sniffer:
   botbanger_port: 22621
   key: "{{botbanger_key}}"
-
-kafka:
-  metadata.broker.list: "{{kafka_broker_ip}}"
-  security.protocol: 'ssl'
-  ssl.ca.location: "{{TSPATH}}/conf/banjax/caroot.pem"
-  ssl.certificate.location: "/{{TSPATH}}/banjax/certificate.pem"
-  ssl.key.location: "/TSPATH/banjax/key.pem"
-  ssl.key.password: "{{banjax_ssl_key_password}}"
-  report_topic: 'banjax_report_topic'
-  command_topic: 'banjax_command_topic'
-  ats_metrics_to_report:
-    - "proxy.process.traffic_server.memory.rss"
-    - "proxy.node.cache.contents.num_docs"
-    - "proxy.process.cache.bytes_total"
-    - "proxy.process.cache.percent_full"
-    - "proxy.process.cache.ram_cache.bytes_used"
-    - "proxy.process.cache.ram_cache.total_bytes"
-    - "proxy.process.net.connections_currently_open"
-    - "proxy.process.current_server_connections"
-    - "proxy.process.http.current_active_client_connections"
-    - "proxy.process.eventloop.time.max"
-
-remove_expired_challenges_interval_seconds: 30
-report_status_interval_seconds: 15

--- a/roles/atsconf/templates/banjax/caroot.pem.j2
+++ b/roles/atsconf/templates/banjax/caroot.pem.j2
@@ -1,1 +1,1 @@
-{% include "config/banjax/caroot.pem" ignore missing %}
+{% include "config/banjax/" + item.key + "/caroot.pem" ignore missing %}

--- a/roles/atsconf/templates/banjax/caroot.pem.j2
+++ b/roles/atsconf/templates/banjax/caroot.pem.j2
@@ -1,0 +1,1 @@
+{% include "config/banjax/caroot.pem" ignore missing %}

--- a/roles/atsconf/templates/banjax/certificate.pem.j2
+++ b/roles/atsconf/templates/banjax/certificate.pem.j2
@@ -1,1 +1,1 @@
-{% include "config/banjax/certificate.pem" ignore missing %}
+{% include "config/banjax/" + item.key + "/certificate.pem" ignore missing %}

--- a/roles/atsconf/templates/banjax/certificate.pem.j2
+++ b/roles/atsconf/templates/banjax/certificate.pem.j2
@@ -1,0 +1,1 @@
+{% include "config/banjax/certificate.pem" ignore missing %}

--- a/roles/atsconf/templates/banjax/dynamic.bconf.j2
+++ b/roles/atsconf/templates/banjax/dynamic.bconf.j2
@@ -17,9 +17,9 @@ challenger:
 kafka:
   metadata.broker.list: "{{ kafka_broker_ip }}"
   security.protocol: 'ssl'
-  ssl.ca.location: "{{ TSPATH }}/conf/banjax/caroot.pem"
-  ssl.certificate.location: "{{ TSPATH }}/banjax/certificate.pem"
-  ssl.key.location: "{{ TSPATH }}/banjax/key.pem"
+  ssl.ca.location: "conf/banjax/caroot.pem"
+  ssl.certificate.location: "conf/banjax/certificate.pem"
+  ssl.key.location: "conf/banjax/key.pem"
   ssl.key.password: "{{ banjax_ssl_key_password }}"
   report_topic: 'banjax_report_topic'
   command_topic: 'banjax_command_topic'

--- a/roles/atsconf/templates/banjax/dynamic.bconf.j2
+++ b/roles/atsconf/templates/banjax/dynamic.bconf.j2
@@ -1,0 +1,38 @@
+---
+# {{ ansible_managed }}
+
+challenger:
+  dynamic_challenger_config:
+    name: "from-kafka-challenge"
+    challenge_type: "sha_inverse"
+    challenge: "solver.html"
+    magic_word:
+      - ['regexp', '.*']
+    validity_period: 360000   # how long a cookie stays valid for
+    white_listed_ips:         # XXX i needed this for some reason
+      - '0.0.0.0'
+    no_of_fails_to_ban: 10    # XXX think about what this should be...
+  dynamic_expiry_seconds: 60  # remove dynamic challenges after this long
+
+kafka:
+  metadata.broker.list: "{{ kafka_broker_ip }}"
+  security.protocol: 'ssl'
+  ssl.ca.location: "{{ TSPATH }}/conf/banjax/caroot.pem"
+  ssl.certificate.location: "{{ TSPATH }}/banjax/certificate.pem"
+  ssl.key.location: "{{ TSPATH }}/banjax/key.pem"
+  ssl.key.password: "{{ banjax_ssl_key_password }}"
+  report_topic: 'banjax_report_topic'
+  command_topic: 'banjax_command_topic'
+  ats_metrics_to_report:
+    - "proxy.process.traffic_server.memory.rss"
+    - "proxy.node.cache.contents.num_docs"
+    - "proxy.process.cache.bytes_total"
+    - "proxy.process.cache.percent_full"
+    - "proxy.process.cache.ram_cache.bytes_used"
+    - "proxy.process.cache.ram_cache.total_bytes"
+    - "proxy.process.net.connections_currently_open"
+    - "proxy.process.current_server_connections"
+    - "proxy.process.http.current_active_client_connections"
+    - "proxy.process.eventloop.time.max"
+remove_expired_challenges_interval_seconds: 30
+report_status_interval_seconds: 15

--- a/roles/atsconf/templates/banjax/dynamic.bconf.j2
+++ b/roles/atsconf/templates/banjax/dynamic.bconf.j2
@@ -17,9 +17,9 @@ challenger:
 kafka:
   metadata.broker.list: "{{ kafka_broker_ip }}"
   security.protocol: 'ssl'
-  ssl.ca.location: "conf/banjax/caroot.pem"
-  ssl.certificate.location: "conf/banjax/certificate.pem"
-  ssl.key.location: "conf/banjax/key.pem"
+  ssl.ca.location: "{{ autodeflect_config.trafficserver_dir }}/conf/banjax/caroot.pem"
+  ssl.certificate.location: "{{ autodeflect_config.trafficserver_dir }}/conf/banjax/certificate.pem"
+  ssl.key.location: "{{ autodeflect_config.trafficserver_dir }}/conf/banjax/key.pem"
   ssl.key.password: "{{ banjax_ssl_key_password }}"
   report_topic: 'banjax_report_topic'
   command_topic: 'banjax_command_topic'

--- a/roles/atsconf/templates/banjax/dynamic.bconf.j2
+++ b/roles/atsconf/templates/banjax/dynamic.bconf.j2
@@ -17,9 +17,9 @@ challenger:
 kafka:
   metadata.broker.list: "{{ kafka_broker_ip }}"
   security.protocol: 'ssl'
-  ssl.ca.location: "{{ autodeflect_config.trafficserver_dir }}/conf/banjax/caroot.pem"
-  ssl.certificate.location: "{{ autodeflect_config.trafficserver_dir }}/conf/banjax/certificate.pem"
-  ssl.key.location: "{{ autodeflect_config.trafficserver_dir }}/conf/banjax/key.pem"
+  ssl.ca.location: "{{ autobrains_config.trafficserver_dir }}/conf/banjax/caroot.pem"
+  ssl.certificate.location: "{{ autobrains_config.trafficserver_dir }}/conf/banjax/certificate.pem"
+  ssl.key.location: "{{ autobrains_config.trafficserver_dir }}/conf/banjax/key.pem"
   ssl.key.password: "{{ banjax_ssl_key_password }}"
   report_topic: 'banjax_report_topic'
   command_topic: 'banjax_command_topic'

--- a/roles/atsconf/templates/banjax/key.pem.j2
+++ b/roles/atsconf/templates/banjax/key.pem.j2
@@ -1,1 +1,1 @@
-{% include "config/banjax/key.pem" ignore missing %}
+{% include "config/banjax/" + item.key + "/key.pem" ignore missing %}

--- a/roles/atsconf/templates/banjax/key.pem.j2
+++ b/roles/atsconf/templates/banjax/key.pem.j2
@@ -1,0 +1,1 @@
+{% include "config/banjax/key.pem" ignore missing %}

--- a/roles/autobrains_update/templates/autobrains_update.sh.j2
+++ b/roles/autobrains_update/templates/autobrains_update.sh.j2
@@ -419,6 +419,29 @@ function banjax_new_diff {
   fi
 }
 
+function banjax_kafka_certs_diff {
+  ATS_DIR="{{ autobrains_config.deflect_dir }}/edges/$DNET{{ autobrains_config.trafficserver_dir }}"
+  for i in {{ banjax_output }}$DNET/*.pem; do
+    ls $i >> config/logs/current.log 2>&1
+    RT=$?
+    if [ "$RT" -gt 0 ]; then
+      continue
+    fi
+    DIFF_FILES="$ATS_DIR/conf/banjax/$(basename $i) $i"
+    diff -Ntu $DIFF_FILES
+    RT=$?
+    if [ $RT -eq 2 ]
+    then
+      echo "ERROR: There was something wrong with the diff command"
+    elif [ $RT -eq 1 ]
+    then
+      yorn "Do you want to install this file" "install_file $i $ATS_DIR/conf/banjax/$(basename $i)"
+      [ "$yn" = 'n' ] || [ "$yn" = 'N' ] && SKIPPED_INSTALL[$DNET]=0 || REMAP_TOUCHED[$DNET]=0
+      echo -e $ECHO_SEPARATOR
+    fi
+  done
+}
+
 # ATS 7+
 function logging_diff {
   ATS_DIR="{{autobrains_config.deflect_dir}}/edges/$DNET{{autobrains_config.trafficserver_dir}}"
@@ -563,6 +586,7 @@ function all_diff {
 for DNET in $DNETS; do
   banjax_new_diff
   banjax_diff_loop
+  banjax_kafka_certs_diff
   logging_diff
   ssl_multicert_diff
   remap_diff


### PR DESCRIPTION
Note this requires two new secret group variables: `kafka_broker_ip` and `banjax_ssl_key_password`.

Also, this should be deployed *after* the new banjax binary is deployed. The old binary will crash with the new config, but the new binary is ok with the old config (just the kafka stuff won't start).